### PR TITLE
:rewind: restore inputStream

### DIFF
--- a/src/main/java/io/github/biezhi/excel/plus/ExcelPlus.java
+++ b/src/main/java/io/github/biezhi/excel/plus/ExcelPlus.java
@@ -15,6 +15,7 @@
  */
 package io.github.biezhi.excel.plus;
 
+import io.github.biezhi.excel.plus.enums.ExcelType;
 import io.github.biezhi.excel.plus.enums.ParseType;
 import io.github.biezhi.excel.plus.exception.ExcelException;
 import io.github.biezhi.excel.plus.handler.CSVHandler;
@@ -97,12 +98,10 @@ public class ExcelPlus {
     public <T> ReaderResult<T> read(Class<T> type, Reader reader) throws ExcelException {
         List<Pair<Integer, T>> result;
         this.beforeCheck(reader);
-
-        boolean is2007 = reader.getExcelFile().getName().toLowerCase().endsWith(".xlsx");
-        if (reader.getParseType().equals(ParseType.SAX) && is2007) {
+        if (reader.getParseType().equals(ParseType.SAX) && reader.getExcelType() == ExcelType.XLSX) {
             result = new Excel2007Handler<>(type, reader).parse();
         } else {
-            if (reader.getExcelFile().getName().endsWith(".csv")) {
+            if (ExcelType.CSV == reader.getExcelType()) {
                 result = new CSVHandler<>(type, reader).parse();
             } else {
                 result = new DefaultExcelHandler<>(type, reader).parse();
@@ -115,11 +114,14 @@ public class ExcelPlus {
         if (null == reader) {
             throw new ExcelException("Reader not is null.");
         }
-        if (null == reader.getExcelFile()) {
+        if (null == reader.getExcelFile() && null == reader.getInputStream()) {
             throw new ExcelException("Excel file not is null.");
         }
         if (null == reader.getParseType()) {
             throw new ExcelException("Excel parse type not is null.");
+        }
+        if (null == reader.getExcelType()) {
+            throw new ExcelException("Excel file type not is null.");
         }
         if (reader.getSheetIndex() < 0) {
             throw new ExcelException("SheetIndex Can't be less than 0.");

--- a/src/main/java/io/github/biezhi/excel/plus/handler/CSVHandler.java
+++ b/src/main/java/io/github/biezhi/excel/plus/handler/CSVHandler.java
@@ -46,7 +46,7 @@ public class CSVHandler<T> implements ExcelHandler {
     @Override
     public List<Pair<Integer, T>> parse() throws ExcelException {
         List<Pair<Integer, T>> list = new ArrayList<>();
-        try (InputStream in = new FileInputStream(reader.getExcelFile())) {
+        try (InputStream in = reader.getExcelFile() != null ? new FileInputStream(reader.getExcelFile()) : reader.getInputStream()) {
             CSV          csv      = new CSV(true, ',', in);
             List<String> colNames = null;
             if (csv.hasNext()) colNames = new ArrayList<>(csv.next());

--- a/src/main/java/io/github/biezhi/excel/plus/handler/DefaultExcelHandler.java
+++ b/src/main/java/io/github/biezhi/excel/plus/handler/DefaultExcelHandler.java
@@ -48,7 +48,11 @@ public class DefaultExcelHandler<T> implements ExcelHandler {
         Workbook workbook;
         Sheet    sheet;
         try {
-            workbook = WorkbookFactory.create(reader.getExcelFile());
+            if(reader.getExcelFile() != null){
+                workbook = WorkbookFactory.create(reader.getExcelFile());
+            } else {
+                workbook = WorkbookFactory.create(reader.getInputStream());
+            }
         } catch (IOException | InvalidFormatException e) {
             throw new ParseException(e);
         }

--- a/src/main/java/io/github/biezhi/excel/plus/handler/Excel2007Handler.java
+++ b/src/main/java/io/github/biezhi/excel/plus/handler/Excel2007Handler.java
@@ -96,8 +96,13 @@ public class Excel2007Handler<T> extends DefaultHandler implements ExcelHandler 
 
     @Override
     public List<Pair<Integer, T>> parse() {
+        OPCPackage pkg;
         try {
-            OPCPackage pkg        = OPCPackage.open(reader.getExcelFile());
+            if(reader.getExcelFile() != null){
+                pkg = OPCPackage.open(reader.getExcelFile());
+            } else {
+                pkg = OPCPackage.open(reader.getInputStream());
+            }
             XSSFReader xssfReader = new XSSFReader(pkg);
             stylesTable = xssfReader.getStylesTable();
             SharedStringsTable    sst    = xssfReader.getSharedStringsTable();

--- a/src/main/java/io/github/biezhi/excel/plus/reader/Reader.java
+++ b/src/main/java/io/github/biezhi/excel/plus/reader/Reader.java
@@ -15,6 +15,7 @@
  */
 package io.github.biezhi.excel.plus.reader;
 
+import io.github.biezhi.excel.plus.enums.ExcelType;
 import io.github.biezhi.excel.plus.enums.ParseType;
 import lombok.Data;
 
@@ -36,6 +37,10 @@ public class Reader {
     private ParseType parseType = ParseType.DOM;
 
     private File excelFile;
+
+    private ExcelType excelType;
+
+    private InputStream inputStream;
 
     public static Reader create() {
         return new Reader();
@@ -63,6 +68,17 @@ public class Reader {
 
     public Reader excelFile(File excelFile) {
         this.excelFile = excelFile;
+        this.excelType = ExcelType.getExcelType(this.excelFile.getName());
+        return this;
+    }
+
+    public Reader inputStream(InputStream inputStream) {
+        this.inputStream = inputStream;
+        return this;
+    }
+
+    public Reader excelType(ExcelType excelType){
+        this.excelType = excelType;
         return this;
     }
 


### PR DESCRIPTION
恢复inputStream参数，因为在web使用场景下，通常直接在request中就获取了excel上传的输入流，而不需要先临时保存中间的Excel File（很多时候服务器不需要保存这个文件）。excel-plus早期的版本是可以直接读取inputStream的，后期不知道出于什么考量删掉了（当时好像是说因为性能），但是不可否认的是这个使用场景还是蛮多的。